### PR TITLE
make console text white after saying build error

### DIFF
--- a/rctc/Program.cs
+++ b/rctc/Program.cs
@@ -253,7 +253,8 @@ namespace ReCT
             {
                 Console.ForegroundColor = ConsoleColor.Red;
                 Console.WriteLine("Build has Failed!");
-                    Console.WriteLine(process.StandardError.ReadToEnd());
+                Console.WriteLine(process.StandardError.ReadToEnd());
+                Console.ForegroundColor = ConsoleColor.White;
             }
         }
 


### PR DESCRIPTION
dont you hate it when your input text becomes red