### PR TITLE
Updated rctc to dotnet 6.0

### DIFF
--- a/rctc/rctc.csproj
+++ b/rctc/rctc.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Mono.Options" Version="6.6.0.161"/>


### PR DESCRIPTION
This should be a good change, especially since the AUR doesn't have dotnet 3.1 anymore!


I attached a proposed and untested PKGBUILD for .net 6 in this message too.
It is a TXT because github.

[PKGBUILD.txt](https://github.com/RedCubeDev-ByteSpace/ReCT/files/9893172/PKGBUILD.txt)